### PR TITLE
fix: Improve frontend error handling for non-JSON responses

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -58,11 +58,20 @@
                     });
 
                     removeTypingIndicator();
-                    const result = await response.json();
 
                     if (!response.ok) {
-                        throw new Error(result.error || 'Falha ao obter resposta.');
+                        let errorMsg = `HTTP Error: ${response.status}`;
+                        try {
+                            const errorResult = await response.json();
+                            errorMsg = errorResult.error || errorMsg;
+                        } catch (e) {
+                            const errorText = await response.text();
+                            errorMsg = errorText.substring(0, 100) || errorMsg;
+                        }
+                        throw new Error(errorMsg);
                     }
+
+                    const result = await response.json();
 
                     threadId = result.threadId; // Atualiza o threadId
                     addMessage('assistant', result.response);

--- a/public/index.html
+++ b/public/index.html
@@ -127,11 +127,20 @@
                         body: JSON.stringify(data),
                     });
 
-                    const result = await response.json();
-
                     if (!response.ok) {
-                        throw new Error(result.error || 'Ocorreu um erro desconhecido.');
+                        let errorMsg = `HTTP Error: ${response.status}`;
+                        try {
+                            const errorResult = await response.json();
+                            errorMsg = errorResult.error || errorMsg;
+                        } catch (e) {
+                            // A resposta não era JSON, pode ser texto ou HTML
+                            const errorText = await response.text();
+                            errorMsg = errorText.substring(0, 100) || errorMsg; // Limita o tamanho
+                        }
+                        throw new Error(errorMsg);
                     }
+
+                    const result = await response.json();
 
                     document.getElementById('chat-url').href = result.chatUrl;
                     document.getElementById('chat-url').textContent = result.chatUrl;


### PR DESCRIPTION
This commit addresses a bug where the frontend would crash with an "Unexpected token" error if it received a non-JSON response (e.g., an HTML 404 page) from a fetch request.

The error handling logic in the JavaScript of `public/index.html` and `public/chat.html` has been made more robust. It now checks if the response is `ok` and, in case of an error, attempts to parse a JSON error message. If that fails, it falls back to reading the response as text, preventing the application from crashing and providing a clearer error message to the user.