### PR TITLE
fix: Refactor frontend error handling to prevent crash

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -60,13 +60,14 @@
                     removeTypingIndicator();
 
                     if (!response.ok) {
-                        let errorMsg = `HTTP Error: ${response.status}`;
-                        try {
-                            const errorResult = await response.json();
-                            errorMsg = errorResult.error || errorMsg;
-                        } catch (e) {
+                        let errorMsg;
+                        const contentType = response.headers.get('content-type');
+                        if (contentType && contentType.includes('application/json')) {
+                            const errorJson = await response.json();
+                            errorMsg = errorJson.error || `HTTP Error: ${response.status}`;
+                        } else {
                             const errorText = await response.text();
-                            errorMsg = errorText.substring(0, 100) || errorMsg;
+                            errorMsg = `Server Error: ${errorText.substring(0, 200)}`;
                         }
                         throw new Error(errorMsg);
                     }

--- a/public/index.html
+++ b/public/index.html
@@ -128,14 +128,14 @@
                     });
 
                     if (!response.ok) {
-                        let errorMsg = `HTTP Error: ${response.status}`;
-                        try {
-                            const errorResult = await response.json();
-                            errorMsg = errorResult.error || errorMsg;
-                        } catch (e) {
-                            // A resposta não era JSON, pode ser texto ou HTML
+                        let errorMsg;
+                        const contentType = response.headers.get('content-type');
+                        if (contentType && contentType.includes('application/json')) {
+                            const errorJson = await response.json();
+                            errorMsg = errorJson.error || `HTTP Error: ${response.status}`;
+                        } else {
                             const errorText = await response.text();
-                            errorMsg = errorText.substring(0, 100) || errorMsg; // Limita o tamanho
+                            errorMsg = `Server Error: ${errorText.substring(0, 200)}`;
                         }
                         throw new Error(errorMsg);
                     }
@@ -146,13 +146,10 @@
                     document.getElementById('chat-url').textContent = result.chatUrl;
                     document.getElementById('embed-code').value = result.embedCode;
 
-                    // Limpa a pré-visualização anterior e insere a nova
                     const previewContainer = document.getElementById('preview-container');
-                    previewContainer.innerHTML = ''; // Limpa
-                    const previewScript = document.createElement('script');
+                    previewContainer.innerHTML = '';
                     const scriptTag = document.createRange().createContextualFragment(result.embedCode);
                     previewContainer.appendChild(scriptTag);
-
 
                     resultDiv.style.display = 'block';
 


### PR DESCRIPTION
This commit resolves a "body stream already read" error in the frontend JavaScript.

The previous error handling logic attempted to read the response body twice in case of an error (once as JSON, then as text), which is not permitted and caused the application to crash.

The logic in `public/index.html` and `public/chat.html` has been refactored to:
1. Check the response status.
2. If an error occurred, check the `Content-Type` header.
3. Read the body stream only *once* as either JSON or text based on the content type.

This ensures robust and crash-free error handling for all network responses.